### PR TITLE
Add Polyglot uninstall cleanup for mirror libraries and rebrand Multi-Lang references

### DIFF
--- a/Jellyfin.Plugin.Polyglot.Tests/Behaviors/UserLibraryAccessBehaviorTests.cs
+++ b/Jellyfin.Plugin.Polyglot.Tests/Behaviors/UserLibraryAccessBehaviorTests.cs
@@ -191,7 +191,7 @@ public class UserLibraryAccessBehaviorTests : IDisposable
     [Fact]
     public void NonManagedLibraries_AreNeverIncludedInManagedAccess()
     {
-        // Scenario: Libraries like "Home Videos" that aren't part of the multi-lang
+        // Scenario: Libraries like "Home Videos" that aren't part of the Polyglot-managed
         // system should NOT be returned by GetExpectedLibraryAccess.
         // They're handled separately to preserve user's existing access.
 

--- a/Jellyfin.Plugin.Polyglot.Tests/Configuration/PluginUninstallTests.cs
+++ b/Jellyfin.Plugin.Polyglot.Tests/Configuration/PluginUninstallTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Jellyfin.Plugin.Polyglot.Tests.TestHelpers;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.Polyglot.Tests.Configuration;
+
+/// <summary>
+/// Tests for plugin uninstall cleanup behavior (OnUninstalling).
+/// </summary>
+public class PluginUninstallTests
+{
+    [Fact]
+    public void OnUninstalling_RemovesMirrorLibrariesAndDirectories()
+    {
+        using var context = new PluginTestContext();
+
+        // Arrange: create a temp base path for mirrors
+        var basePath = Path.Combine(Path.GetTempPath(), "polyglot_uninstall_base_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(basePath);
+
+        var alternative = context.AddLanguageAlternative("Portuguese", "pt-BR", basePath);
+
+        var sourceId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+        var targetDir = Path.Combine(basePath, "Movies (Portuguese)");
+        Directory.CreateDirectory(targetDir);
+
+        var mirror = context.AddMirror(
+            alternative,
+            sourceId,
+            "Movies",
+            targetLibraryId: targetId,
+            targetPath: targetDir);
+
+        // Expect the plugin to remove the Jellyfin virtual folder with refreshLibrary: true
+        context.LibraryManagerMock
+            .Setup(m => m.RemoveVirtualFolder(mirror.TargetLibraryName, true))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        // Act
+        context.PluginInstance.OnUninstalling();
+
+        // Assert: library removal was invoked
+        context.LibraryManagerMock.Verify(
+            m => m.RemoveVirtualFolder(mirror.TargetLibraryName, true),
+            Times.Once);
+
+        // Mirror directory should have been deleted
+        Directory.Exists(targetDir).Should().BeFalse("mirror directories should be removed on uninstall");
+    }
+
+    [Fact]
+    public void OnUninstalling_DoesNotDeleteDirectoriesOutsideBasePath()
+    {
+        using var context = new PluginTestContext();
+
+        // Arrange: base path and an external directory not under that base
+        var basePath = Path.Combine(Path.GetTempPath(), "polyglot_uninstall_base_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(basePath);
+
+        var externalDir = Path.Combine(Path.GetTempPath(), "polyglot_uninstall_external_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(externalDir);
+
+        var alternative = context.AddLanguageAlternative("Portuguese", "pt-BR", basePath);
+
+        var sourceId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        // TargetPath is outside the configured base path
+        context.AddMirror(
+            alternative,
+            sourceId,
+            "Movies",
+            targetLibraryId: targetId,
+            targetPath: externalDir);
+
+        // Act
+        context.PluginInstance.OnUninstalling();
+
+        // Assert: external directory should not be deleted because it's outside DestinationBasePath
+        Directory.Exists(externalDir).Should().BeTrue("paths outside the base path must not be deleted on uninstall");
+    }
+}
+
+

--- a/Jellyfin.Plugin.Polyglot.Tests/Helpers/FileSystemHelperTests.cs
+++ b/Jellyfin.Plugin.Polyglot.Tests/Helpers/FileSystemHelperTests.cs
@@ -139,7 +139,7 @@ public class FileSystemHelperTests
     public void CreateHardLink_ValidSourceFile_CreatesHardlink()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), "multilang_test_" + Guid.NewGuid().ToString("N"));
+        var tempDir = Path.Combine(Path.GetTempPath(), "polyglot_test_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
 
         var sourcePath = Path.Combine(tempDir, "source.txt");
@@ -174,7 +174,7 @@ public class FileSystemHelperTests
     public void CreateHardLink_CreatesParentDirectories()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), "multilang_test_" + Guid.NewGuid().ToString("N"));
+        var tempDir = Path.Combine(Path.GetTempPath(), "polyglot_test_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
 
         var sourcePath = Path.Combine(tempDir, "source.txt");
@@ -209,7 +209,7 @@ public class FileSystemHelperTests
     public void CreateHardLink_OverwritesExistingFile()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), "multilang_test_" + Guid.NewGuid().ToString("N"));
+        var tempDir = Path.Combine(Path.GetTempPath(), "polyglot_test_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
 
         var sourcePath = Path.Combine(tempDir, "source.txt");
@@ -428,7 +428,7 @@ public class FileSystemHelperTests
     public void AreOnSameFilesystem_SameDirectory_ReturnsTrue()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), "multilang_test_" + Guid.NewGuid().ToString("N"));
+        var tempDir = Path.Combine(Path.GetTempPath(), "polyglot_test_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
 
         var path1 = Path.Combine(tempDir, "dir1");
@@ -466,7 +466,7 @@ public class FileSystemHelperTests
     public void CleanupEmptyDirectories_RemovesEmptyDirs()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), "multilang_test_" + Guid.NewGuid().ToString("N"));
+        var tempDir = Path.Combine(Path.GetTempPath(), "polyglot_test_" + Guid.NewGuid().ToString("N"));
         var nestedDir = Path.Combine(tempDir, "a", "b", "c");
         Directory.CreateDirectory(nestedDir);
 
@@ -499,7 +499,7 @@ public class FileSystemHelperTests
     public void CleanupEmptyDirectories_StopsAtNonEmptyDir()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), "multilang_test_" + Guid.NewGuid().ToString("N"));
+        var tempDir = Path.Combine(Path.GetTempPath(), "polyglot_test_" + Guid.NewGuid().ToString("N"));
         var nestedDir = Path.Combine(tempDir, "a", "b", "c");
         Directory.CreateDirectory(nestedDir);
 

--- a/Jellyfin.Plugin.Polyglot.Tests/Services/MirrorServiceTests.cs
+++ b/Jellyfin.Plugin.Polyglot.Tests/Services/MirrorServiceTests.cs
@@ -121,7 +121,7 @@ public class MirrorServiceFileOperationTests : IDisposable
 
     public MirrorServiceFileOperationTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), "multilang_test_" + Guid.NewGuid().ToString("N"));
+        _tempDir = Path.Combine(Path.GetTempPath(), "polyglot_test_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempDir);
 
         _libraryManagerMock = new Mock<ILibraryManager>();
@@ -551,7 +551,7 @@ public class MirrorServiceCleanupTests : IDisposable
         var alternative = _context.AddLanguageAlternative("Portuguese", "pt-BR");
 
         // Use a real temp directory so we can verify deletion behavior
-        var tempDir = Path.Combine(Path.GetTempPath(), "multilang_cleanup_" + Guid.NewGuid().ToString("N"));
+        var tempDir = Path.Combine(Path.GetTempPath(), "polyglot_cleanup_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
 
         var mirror = _context.AddMirror(

--- a/Jellyfin.Plugin.Polyglot.Tests/Tasks/ScheduledTaskTests.cs
+++ b/Jellyfin.Plugin.Polyglot.Tests/Tasks/ScheduledTaskTests.cs
@@ -31,9 +31,9 @@ public class MirrorSyncTaskTests : IDisposable
     [Fact]
     public void TaskMetadata_HasCorrectValues()
     {
-        _task.Name.Should().Be("Multi-Lang Mirror Sync");
+        _task.Name.Should().Be("Polyglot Mirror Sync");
         _task.Key.Should().Be("PolyglotMirrorSync");
-        _task.Category.Should().Be("Multi-Language");
+        _task.Category.Should().Be("Polyglot");
     }
 
     [Fact]
@@ -159,9 +159,9 @@ public class UserLanguageSyncTaskTests : IDisposable
     [Fact]
     public void TaskMetadata_HasCorrectValues()
     {
-        _task.Name.Should().Be("Multi-Lang User Library Sync");
+        _task.Name.Should().Be("Polyglot User Library Sync");
         _task.Key.Should().Be("PolyglotUserSync");
-        _task.Category.Should().Be("Multi-Language");
+        _task.Category.Should().Be("Polyglot");
     }
 
     [Fact]

--- a/Jellyfin.Plugin.Polyglot.Tests/TestHelpers/PluginTestContext.cs
+++ b/Jellyfin.Plugin.Polyglot.Tests/TestHelpers/PluginTestContext.cs
@@ -46,7 +46,7 @@ public class PluginTestContext : IDisposable
         // Lock to prevent race conditions with Plugin.Instance during parallel test execution
         Monitor.Enter(_lock);
         
-        _tempConfigPath = Path.Combine(Path.GetTempPath(), "multilang_test_" + Guid.NewGuid().ToString("N"));
+        _tempConfigPath = Path.Combine(Path.GetTempPath(), "polyglot_test_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempConfigPath);
 
         var applicationPathsMock = new Mock<IApplicationPaths>();

--- a/Jellyfin.Plugin.Polyglot.Tests/TestHelpers/PluginTestContext.cs
+++ b/Jellyfin.Plugin.Polyglot.Tests/TestHelpers/PluginTestContext.cs
@@ -1,7 +1,9 @@
 using Jellyfin.Plugin.Polyglot.Configuration;
 using Jellyfin.Plugin.Polyglot.Models;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Jellyfin.Plugin.Polyglot.Tests.TestHelpers;
@@ -21,6 +23,17 @@ public class PluginTestContext : IDisposable
     private static readonly object _lock = new();
 
     public PluginConfiguration Configuration => _plugin.Configuration;
+
+    /// <summary>
+    /// Gets the mock library manager used when constructing the plugin.
+    /// Useful for verifying interactions such as uninstall cleanup.
+    /// </summary>
+    public Mock<ILibraryManager> LibraryManagerMock { get; }
+
+    /// <summary>
+    /// Gets the mock logger used when constructing the plugin.
+    /// </summary>
+    public Mock<ILogger<Plugin>> PluginLoggerMock { get; }
     
     /// <summary>
     /// Gets the Plugin instance created by this context.
@@ -46,7 +59,14 @@ public class PluginTestContext : IDisposable
             .Returns(new PluginConfiguration());
         xmlSerializerMock.Setup(s => s.SerializeToFile(It.IsAny<object>(), It.IsAny<string>()));
 
-        _plugin = new Plugin(applicationPathsMock.Object, xmlSerializerMock.Object);
+        LibraryManagerMock = new Mock<ILibraryManager>();
+        PluginLoggerMock = new Mock<ILogger<Plugin>>();
+
+        _plugin = new Plugin(
+            applicationPathsMock.Object,
+            xmlSerializerMock.Object,
+            LibraryManagerMock.Object,
+            PluginLoggerMock.Object);
         
         // Verify Plugin.Instance is set correctly
         if (!ReferenceEquals(Plugin.Instance, _plugin))

--- a/Jellyfin.Plugin.Polyglot/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Polyglot/Configuration/PluginConfiguration.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Model.Plugins;
 namespace Jellyfin.Plugin.Polyglot.Configuration;
 
 /// <summary>
-/// Plugin configuration for Multi-Language Library.
+/// Plugin configuration for the Polyglot plugin.
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
 {

--- a/Jellyfin.Plugin.Polyglot/Helpers/FileSystemHelper.cs
+++ b/Jellyfin.Plugin.Polyglot/Helpers/FileSystemHelper.cs
@@ -185,7 +185,7 @@ public static class FileSystemHelper
         bool createdTestFile = false;
         if (testSourceFile == null)
         {
-            testSourceFile = Path.Combine(sourceDir, $".multilang_test_{Guid.NewGuid():N}");
+            testSourceFile = Path.Combine(sourceDir, $".polyglot_test_{Guid.NewGuid():N}");
             try
             {
                 File.WriteAllText(testSourceFile, "test");
@@ -224,7 +224,7 @@ public static class FileSystemHelper
         }
 
         // Try to create a test hardlink
-        var testLinkPath = Path.Combine(targetDir, $".multilang_test_{Guid.NewGuid():N}");
+        var testLinkPath = Path.Combine(targetDir, $".polyglot_test_{Guid.NewGuid():N}");
         bool canHardlink = false;
 
         try

--- a/Jellyfin.Plugin.Polyglot/Plugin.cs
+++ b/Jellyfin.Plugin.Polyglot/Plugin.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Jellyfin.Plugin.Polyglot.Configuration;
+using Jellyfin.Plugin.Polyglot.Helpers;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Polyglot;
 
@@ -14,6 +18,9 @@ namespace Jellyfin.Plugin.Polyglot;
 /// </summary>
 public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
+    private readonly ILibraryManager _libraryManager;
+    private readonly ILogger<Plugin> _logger;
+
     /// <summary>
     /// Gets the current plugin instance.
     /// </summary>
@@ -24,10 +31,18 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     /// <param name="applicationPaths">The application paths.</param>
     /// <param name="xmlSerializer">The XML serializer.</param>
-    public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
+    /// <param name="libraryManager">The Jellyfin library manager.</param>
+    /// <param name="logger">The plugin logger.</param>
+    public Plugin(
+        IApplicationPaths applicationPaths,
+        IXmlSerializer xmlSerializer,
+        ILibraryManager libraryManager,
+        ILogger<Plugin> logger)
         : base(applicationPaths, xmlSerializer)
     {
         Instance = this;
+        _libraryManager = libraryManager;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -63,5 +78,91 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public new void SaveConfiguration()
     {
         SaveConfiguration(Configuration);
+    }
+
+    /// <inheritdoc />
+    public override void OnUninstalling()
+    {
+        var config = Configuration;
+
+        try
+        {
+            _logger.LogInformation("Polyglot plugin uninstall: starting cleanup of mirror libraries and directories");
+
+            foreach (var alternative in config.LanguageAlternatives)
+            {
+                foreach (var mirror in alternative.MirroredLibraries)
+                {
+                    // Remove Jellyfin virtual folders created for mirrors
+                    if (mirror.TargetLibraryId.HasValue && !string.IsNullOrWhiteSpace(mirror.TargetLibraryName))
+                    {
+                        try
+                        {
+                            _logger.LogInformation(
+                                "Polyglot uninstall: removing mirror library {LibraryName}",
+                                mirror.TargetLibraryName);
+
+                            // Block until removal completes so we don't leave behind references
+                            _libraryManager
+                                .RemoveVirtualFolder(mirror.TargetLibraryName, true)
+                                .GetAwaiter()
+                                .GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(
+                                ex,
+                                "Polyglot uninstall: failed to remove mirror library {LibraryName}",
+                                mirror.TargetLibraryName);
+                        }
+                    }
+
+                    // Delete mirror directories, but only when safely under the configured base path
+                    if (!string.IsNullOrWhiteSpace(mirror.TargetPath)
+                        && !string.IsNullOrWhiteSpace(alternative.DestinationBasePath)
+                        && Directory.Exists(mirror.TargetPath)
+                        && FileSystemHelper.IsPathSafe(mirror.TargetPath, alternative.DestinationBasePath))
+                    {
+                        try
+                        {
+                            _logger.LogInformation(
+                                "Polyglot uninstall: deleting mirror directory {Path}",
+                                mirror.TargetPath);
+
+                            Directory.Delete(mirror.TargetPath, true);
+
+                            // Clean up any empty parent directories up to the base path
+                            var parent = Path.GetDirectoryName(mirror.TargetPath)
+                                         ?? alternative.DestinationBasePath;
+                            FileSystemHelper.CleanupEmptyDirectories(parent, alternative.DestinationBasePath);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(
+                                ex,
+                                "Polyglot uninstall: failed to delete mirror directory {Path}",
+                                mirror.TargetPath);
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Polyglot plugin uninstall: unexpected error during cleanup");
+        }
+
+        // Clear configuration to avoid leaving stale state behind on disk
+        try
+        {
+            config.LanguageAlternatives.Clear();
+            config.UserLanguages.Clear();
+            config.LdapGroupMappings.Clear();
+            SaveConfiguration();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Polyglot plugin uninstall: failed to save cleaned configuration");
+        }
     }
 }

--- a/Jellyfin.Plugin.Polyglot/Services/LibraryAccessService.cs
+++ b/Jellyfin.Plugin.Polyglot/Services/LibraryAccessService.cs
@@ -212,7 +212,7 @@ public class LibraryAccessService : ILibraryAccessService
             yield break;
         }
 
-        // Get all libraries that are part of the multi-lang system
+        // Get all libraries that are part of the Polyglot-managed system
         var managedLibraries = GetManagedLibraryIds();
 
         // Get all Jellyfin libraries
@@ -263,7 +263,7 @@ public class LibraryAccessService : ILibraryAccessService
 
             if (!isManaged)
             {
-                // This library is NOT part of the multi-lang system (like "Home Videos")
+                // This library is NOT part of the Polyglot-managed system (like "Home Videos")
                 // We don't include it here - it will be handled separately to preserve user's existing access
                 continue;
             }

--- a/Jellyfin.Plugin.Polyglot/Tasks/MirrorSyncTask.cs
+++ b/Jellyfin.Plugin.Polyglot/Tasks/MirrorSyncTask.cs
@@ -26,7 +26,7 @@ public class MirrorSyncTask : IScheduledTask
     }
 
     /// <inheritdoc />
-    public string Name => "Multi-Lang Mirror Sync";
+    public string Name => "Polyglot Mirror Sync";
 
     /// <inheritdoc />
     public string Key => "PolyglotMirrorSync";
@@ -35,7 +35,7 @@ public class MirrorSyncTask : IScheduledTask
     public string Description => "Synchronizes all language mirror libraries with their source libraries.";
 
     /// <inheritdoc />
-    public string Category => "Multi-Language";
+    public string Category => "Polyglot";
 
     /// <inheritdoc />
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()

--- a/Jellyfin.Plugin.Polyglot/Tasks/UserLanguageSyncTask.cs
+++ b/Jellyfin.Plugin.Polyglot/Tasks/UserLanguageSyncTask.cs
@@ -31,7 +31,7 @@ public class UserLanguageSyncTask : IScheduledTask
     }
 
     /// <inheritdoc />
-    public string Name => "Multi-Lang User Library Sync";
+    public string Name => "Polyglot User Library Sync";
 
     /// <inheritdoc />
     public string Key => "PolyglotUserSync";
@@ -40,7 +40,7 @@ public class UserLanguageSyncTask : IScheduledTask
     public string Description => "Reconciles user library access permissions with their language assignments.";
 
     /// <inheritdoc />
-    public string Category => "Multi-Language";
+    public string Category => "Polyglot";
 
     /// <inheritdoc />
     public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()


### PR DESCRIPTION
### PR description

**Summary**

- **Rebrand remaining “Multi-Lang” references to “Polyglot”** in configuration docs, scheduled task metadata, comments, and temp file/directory prefixes.
- **Add robust uninstall cleanup for Polyglot mirrors**, ensuring Jellyfin virtual folders and on-disk mirror directories are removed safely when the plugin is uninstalled.

### Details

- **Plugin uninstall cleanup**
  - Extend `Plugin` to depend on `ILibraryManager` and `ILogger<Plugin>` and override `OnUninstalling`.
  - On uninstall, iterate over all configured `LanguageAlternatives` and their `MirroredLibraries`:
    - For each mirror with a valid `TargetLibraryId` and `TargetLibraryName`, call `_libraryManager.RemoveVirtualFolder(..., refreshLibrary: true)` and log success/failure.
    - For each mirror with a `TargetPath`, `DestinationBasePath`, and existing directory:
      - Only delete the directory when `FileSystemHelper.IsPathSafe(TargetPath, DestinationBasePath)` returns true.
      - After deletion, call `FileSystemHelper.CleanupEmptyDirectories` to prune empty parents up to the base path.
  - Wrap the entire process in error handling:
    - Log unexpected errors at `Error` level, and per-mirror failures at `Warning` level.
    - Clear `LanguageAlternatives`, `UserLanguages`, and `LdapGroupMappings` and persist the cleaned configuration, logging any failure to save.

- **Polyglot naming and test temp paths**
  - Update scheduled task names and categories:
    - `"Multi-Lang Mirror Sync"` → `"Polyglot Mirror Sync"`, category `"Polyglot"`.
    - `"Multi-Lang User Library Sync"` → `"Polyglot User Library Sync"`, category `"Polyglot"`.
  - Refresh comments to talk about the “Polyglot-managed system” instead of “multi-lang”.
  - Change temp file/directory prefixes from `multilang_*` to `polyglot_*` in helpers and tests (e.g., `.polyglot_test_*`, `polyglot_test_*`, `polyglot_cleanup_*`).
  - Clarify plugin configuration summary to mention “Polyglot plugin”.

- **Test infrastructure and coverage**
  - Enhance `PluginTestContext` to:
    - Create and expose `LibraryManagerMock` and `PluginLoggerMock`.
    - Construct `Plugin` with the new dependencies.
    - Continue to use a temp config directory (now `polyglot_test_*`) and validate `Plugin.Instance`.
  - Add `PluginUninstallTests` to verify:
    - Mirror libraries are removed via `ILibraryManager.RemoveVirtualFolder` and mirror directories under the configured base path are deleted on uninstall.
    - Directories outside the configured `DestinationBasePath` are **not** deleted, even if referenced by a mirror.
  - Update existing tests (`ScheduledTaskTests`, `MirrorServiceTests`, `FileSystemHelperTests`, `UserLibraryAccessBehaviorTests`) to match the new naming and temp path conventions.

### Testing

- **Unit tests**
  - Added `PluginUninstallTests` to assert both positive cleanup and safety around paths outside the base directory.
  - Updated existing tests to use the new Polyglot names and prefixes so they remain green under the new behavior.